### PR TITLE
change license from MIT to CC BY-NC-SA 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 
 # License
 
-[MIT License](LICENSE)
+[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh).


### PR DESCRIPTION
The MIT license is used for code. However, the notes is like knowledge
share. I think the CC BY-NC-SA 4.0 is better than MIT license.